### PR TITLE
Added explicit domains. Restored private network

### DIFF
--- a/manifests/resources/tenant.pp
+++ b/manifests/resources/tenant.pp
@@ -1,12 +1,14 @@
 define openstack::resources::tenant (
   $description,
   $enabled = true,
+  $domain = 'Default',
 ) {
 
   keystone_tenant { $name:
     ensure      => present,
     description => $description,
     enabled     => $enabled,
+    domain      => $domain,
   }
 
 }

--- a/manifests/resources/user.pp
+++ b/manifests/resources/user.pp
@@ -4,23 +4,29 @@ define openstack::resources::user (
   $email,
   $admin   = false,
   $enabled = true,
+  $domain = 'Default',
 ) {
   keystone_user { $name:
     ensure   => present,
     enabled  => $enabled,
     password => $password,
     email    => $email,
+    domain   => $domain,
   }
 
   if $admin == true {
     keystone_user_role { "${name}@${tenant}":
-      ensure  => present,
-      roles   => ['_member_', 'admin', 'heat_stack_owner'],
+      ensure         => present,
+      roles          => ['_member_', 'admin', 'heat_stack_owner'],
+      user_domain    => $domain,
+      project_domain => $domain,
     }
   } else {
     keystone_user_role { "${name}@${tenant}":
       ensure => present,
       roles  => ['_member_', 'heat_stack_owner'],
+      user_domain    => $domain,
+      project_domain => $domain,
     }
   }
 }

--- a/manifests/setup/sharednetwork.pp
+++ b/manifests/setup/sharednetwork.pp
@@ -35,22 +35,22 @@ class openstack::setup::sharednetwork {
     dns_nameservers  => [$dns],
   }
 
-  #  neutron_network { 'private':
-  #  tenant_name              => 'openstack',
-  #  provider_network_type    => 'gre',
-  #  router_external          => false,
-  #  provider_segmentation_id => 4063,
-  #  shared                   => true,
-  #} ->
-  #
-  #neutron_subnet { $private_network:
-  #  cidr            => $private_network,
-  #  ip_version      => '4',
-  #  enable_dhcp     => true,
-  #  network_name    => 'private',
-  #  tenant_name     => 'openstack',
-  #  dns_nameservers => [$dns],
-  #}
-  #
-  #openstack::setup::router { "openstack:${private_network}": }
+  neutron_network { 'private':
+    tenant_name              => 'openstack',
+    provider_network_type    => 'gre',
+    router_external          => false,
+    provider_segmentation_id => 4063,
+    shared                   => true,
+  } ->
+  
+  neutron_subnet { $private_network:
+    cidr            => $private_network,
+    ip_version      => '4',
+    enable_dhcp     => true,
+    network_name    => 'private',
+    tenant_name     => 'openstack',
+    dns_nameservers => [$dns],
+  }
+  
+  openstack::setup::router { "openstack:${private_network}": }
 }


### PR DESCRIPTION
Explicitly state 'Default' domain for users, tenants, and roles.
Restored the previosly removed private network generation.
